### PR TITLE
use --force with hg strip

### DIFF
--- a/hg-cache/hgutils.py
+++ b/hg-cache/hgutils.py
@@ -64,7 +64,7 @@ def hg_log(local, ui=None, cache=None, use_self=False):
 
 def hg_strip(local, revset, ui=None, cache=None, use_self=False):
     return execute_hg_in_subdir_or_die(
-        local, ["strip", "-r", revset, "--config", "extensions.strip="],
+        local, ["strip", "--force", "-r", revset, "--config", "extensions.strip="],
         ui=ui, cache=cache, use_self=use_self)
 
 


### PR DESCRIPTION
To avoid things like http://jenkins.dssl.local:8080/job/staging/job/D5167/job/test/job/grabbers/7/console
```
00:00:53.972    File "/var/lib/jenkins.MSK-SLAVE-00L/.local/lib/python2.7/site-packages/hg-cache/__init__.py", line 32, in _pull_with_cache
00:00:53.972      rc, out = hg_strip(".", "outgoing('%s')" % cache_dir, ui=ui)
00:00:53.972    File "/var/lib/jenkins.MSK-SLAVE-00L/.local/lib/python2.7/site-packages/hg-cache/hgutils.py", line 68, in hg_strip
00:00:53.972      ui=ui, cache=cache, use_self=use_self)
00:00:53.972    File "/var/lib/jenkins.MSK-SLAVE-00L/.local/lib/python2.7/site-packages/hg-cache/exeutils.py", line 60, in execute_hg_in_subdir_or_die
00:00:53.972      raise SubcommandException(rc, os.path.abspath("%s" % subdir), cmd, out)
00:00:53.972  hgext_hgcache.exeutils.SubcommandException: 
00:00:53.972  EXIT=255
00:00:53.972  DIR=/var/lib/jenkins.MSK-SLAVE-00L/workspace/staging/D5167/test/grabbers
00:00:53.972  CMD=['hg', 'strip', '-r', "outgoing('/var/lib/jenkins.MSK-SLAVE-00L/.hgcache/trassir')", '--config', 'extensions.strip=', '--config', 'extensions.hgcache=!']
00:00:53.972  abort: local changes found
```
(caused by)
```
bash-4.2$ hg status
! tech1utils/i18n/t1utils-es.ts
! tech1utils/i18n/t1utils-ru.ts
! tech1utils/i18n/t1utils-tr.ts
```